### PR TITLE
Update .bash_profile to .zshrc due to default shell change in macOS

### DIFF
--- a/mac_setup.sh
+++ b/mac_setup.sh
@@ -2,7 +2,13 @@
 
 brew install jq
 
-echo -e "\nalias wiki='`pwd`/wiki.sh'" >> ~/.zshrc
-source ~/.zshrc
+SOURCE_FILE=~/.bash_profile
 
-
+# check if current shell is
+# zsh and change source file
+# accordingly
+if [ $SHELL == "/bin/zsh" ]; then
+    SOURCE_FILE=~/.zshrc
+fi
+echo -e "\nalias wiki='`pwd`/wiki.sh'" >> $SOURCE_FILE
+source $SOURCE_FILE

--- a/mac_setup.sh
+++ b/mac_setup.sh
@@ -2,7 +2,7 @@
 
 brew install jq
 
-echo -e "\nalias wiki='`pwd`/wiki.sh'" >> ~/.bash_profile
-source ~/.bash_profile
+echo -e "\nalias wiki='`pwd`/wiki.sh'" >> ~/.zshrc
+source ~/.zshrc
 
 


### PR DESCRIPTION
I know that the project in called Wiki-bash, but in newer macOS versions (starting with Catalina iirc), the default shell is no longer bash but zsh, which uses `~/.zshrc` instead of `.bash_profile`